### PR TITLE
feat: introduce git sign

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: master
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Run release.mjs
         run: node ./cli.mjs
         env:
-          VERBOSE: ${{ secrets.VERBOSE }}
-          GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMITTER_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.GIT_COMMITTER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GIT_COMMITTER_EMAIL }}
+          GIT_SIGN_KEY: ${{ secrets.GIT_SIGN_KEY }}
           GH_USER: x-access-token
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_OIDC: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: Zizmor
 
 on:
   push:
-    branches: ['main']
+    branches: ['master']
   pull_request:
     branches: ['**']
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,14 +17,14 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
 
       - name: Run zizmor
-        run: uvx zizmor@1.23.1 .github/workflows -v -p --min-severity=medium
+        run: uvx zizmor@1.28.0 .github/workflows -v -p --min-severity=medium

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Testing git sign
+.ssh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Btw, here's an adaptation for monorepos: [zx-bulk-release](https://github.com/se
 * Poor [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) analysis
 * `CHANGELOG.md` generation
 * `package.json` version bumping
-* Git release commit creation
+* Git release commit creation (optionally [SSH-signed](#signed-release-commits-opt-in))
 * [GitHub Release](https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release)
 * Package publishing to both [npmjs](https://registry.npmjs.org) and [gh](http://npm.pkg.github.com) registries
 
@@ -65,6 +65,28 @@ Auto-detection: if `NPM_OIDC` is not set and `NPM_TOKEN` is absent, OIDC is used
 * Requires **npm >= 11.5.1** and **Node.js >= 22.14.0**
 * An existing project `.npmrc` with an `_authToken` for `registry.npmjs.org` will override OIDC — remove it to use trusted publishing
 * OIDC applies to **npmjs.org only**; GitHub Packages still uses `GITHUB_TOKEN` / `GH_TOKEN`
+
+### Signed release commits (opt-in)
+Branch [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets) with **Require signed commits** reject the release commit, because zx-semrel creates it with a plain, unsigned local `git commit`. Set `GIT_SIGN_KEY` to sign the release commit **and** tag with SSH.
+
+`GIT_SIGN_KEY` — the **private** SSH key of the committer identity (the full multi-line key, e.g. the contents of an `id_ed25519` file). When set, zx-semrel writes it to a temporary `0600` file and enables SSH signing via **local** git config only (`gpg.format ssh`, `user.signingkey`, `commit.gpgsign`, `tag.gpgsign`) — it never touches your global git config. When unset, behaviour is unchanged (unsigned commit).
+
+```yaml
+# .github/workflows/release.yml
+env:
+  GIT_COMMITTER_NAME: Semrel Extra Bot
+  GIT_COMMITTER_EMAIL: bot@example.com          # must be a verified email on the account below
+  GIT_SIGN_KEY: ${{ secrets.GIT_SIGN_KEY }}     # PEM-format private key, incl. the BEGIN/END lines
+```
+
+For GitHub to show **Verified** (rather than **Unverified**):
+* Add the matching **public** key to the committing account at **Settings → SSH and GPG keys → New SSH key**, choosing **Key type: Signing Key** (not the default *Authentication Key*).
+* That account must have a **verified email equal to `GIT_COMMITTER_EMAIL`** — GitHub matches the signature to the identity by the committer email.
+
+Notes:
+* SSH format only for now; GPG signing is out of scope.
+* Generate a dedicated key, e.g. `ssh-keygen -t ed25519 -C bot@example.com -f ./sign_key`, store the private half as the `GIT_SIGN_KEY` secret, and register `sign_key.pub` as a Signing Key.
+* The bot account still needs push access to the protected branch (rulesets apply to everyone unless bypassed).
 
 ### 🛠️ Extras
 * [zx + semrel + maven](https://gist.github.com/malys/f295388ac10c8fc30b8912598b13ceb6) by [@malys](https://github.com/malys)

--- a/release.mjs
+++ b/release.mjs
@@ -6,7 +6,7 @@ export default (async () => {
   $.verbose = !!env.VERBOSE
   $.noquote = $({quote: v => v})
 
-  const {GIT_BRANCH, GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL, GITHUB_TOKEN, GH_TOKEN, GH_USER, PKG_ALIAS, PUSH_MAJOR_TAG, NPM_TOKEN, NPM_OIDC, NPM_PROVENANCE, ACTIONS_ID_TOKEN_REQUEST_URL, DEBUG, DRY_RUN} = env
+  const {GIT_BRANCH, GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL, GIT_SIGN_KEY, GITHUB_TOKEN, GH_TOKEN, GH_USER, PKG_ALIAS, PUSH_MAJOR_TAG, NPM_TOKEN, NPM_OIDC, NPM_PROVENANCE, ACTIONS_ID_TOKEN_REQUEST_URL, DEBUG, DRY_RUN} = env
   const ghAuth = GITHUB_TOKEN || GH_TOKEN
   const npmOidc = NPM_OIDC || (!NPM_TOKEN && ACTIONS_ID_TOKEN_REQUEST_URL)
 
@@ -95,6 +95,17 @@ export default (async () => {
 
   await $`git config user.name ${committerName}`
   await $`git config user.email ${committerEmail}`
+
+  // opt-in commit signing (SSH). Local git config only — never global.
+  if (GIT_SIGN_KEY) {
+    const keyFile = path.join(os.tmpdir(), 'zx-semrel-ssh-signing-key')
+    fs.writeFileSync(keyFile, GIT_SIGN_KEY.trim() + '\n', {mode: 0o600})
+    await $`git config gpg.format ssh`
+    await $`git config user.signingkey ${keyFile}`
+    await $`git config commit.gpgsign true`
+    await $`git config tag.gpgsign true`
+  }
+
   await $`git remote set-url origin ${repoAuthUrl}`
 
   console.log('git push')

--- a/test.mjs
+++ b/test.mjs
@@ -3,7 +3,7 @@ import {test, describe, beforeEach, afterEach} from 'node:test'
 import assert from 'node:assert'
 import {PassThrough} from 'node:stream'
 import {EventEmitter} from 'node:events'
-import {mkdtempSync, writeFileSync, rmSync, readFileSync} from 'node:fs'
+import {mkdtempSync, writeFileSync, rmSync, readFileSync, statSync, existsSync} from 'node:fs'
 import {join} from 'node:path'
 import {tmpdir} from 'node:os'
 
@@ -58,6 +58,11 @@ const gitResponses = (overrides = {}) => [
 
 let tmpDir, origCwd, origEnv
 
+// release.mjs writes the opt-in SSH signing key to this fixed path in os.tmpdir()
+const signKeyFile = join(tmpdir(), 'zx-semrel-ssh-signing-key')
+// synthetic multi-line key material — git is mocked, so it need not be a real key
+const signKey = 'zx-semrel-test-key-line-1\nzx-semrel-test-key-line-2\nzx-semrel-test-key-line-3'
+
 const baseEnv = {
   PATH: process.env.PATH,
   HOME: process.env.HOME,
@@ -82,6 +87,7 @@ afterEach(() => {
   process.chdir(origCwd)
   $.env = origEnv
   rmSync(tmpDir, {recursive: true, force: true})
+  rmSync(signKeyFile, {force: true})
 })
 
 async function run(mock, env) {
@@ -211,5 +217,65 @@ describe('release.mjs', () => {
     }))
     await run(mock)
     assert.ok(has(mock.calls, 'version 1.0.0'))
+  })
+
+  test('GIT_SIGN_KEY — enables SSH signing via local git config and writes 0600 key file', async () => {
+    rmSync(signKeyFile, {force: true})
+    const mock = createMock(gitResponses({
+      log: '+++fix: sign the release____sig1__sig1full',
+    }))
+    // surrounding whitespace proves the key is trimmed before writing
+    await run(mock, {GIT_SIGN_KEY: `\n${signKey}\n`})
+
+    // SSH signing configured — locally only, never --global
+    assert.ok(has(mock.calls, 'git config gpg.format ssh'))
+    assert.ok(has(mock.calls, 'git config user.signingkey'))
+    assert.ok(has(mock.calls, 'git config commit.gpgsign true'))
+    assert.ok(has(mock.calls, 'git config tag.gpgsign true'))
+    assert.ok(!mock.calls.some(c => c.includes('--global')), 'signing must never touch global git config')
+    // signingkey points at the written key file
+    assert.ok(mock.calls.some(c => c.includes('user.signingkey') && c.includes(signKeyFile)))
+    // release still proceeds
+    assert.ok(has(mock.calls, 'git commit'))
+    assert.ok(has(mock.calls, 'git push'))
+
+    // key material preserved exactly: multi-line, single trailing newline, mode 0600
+    const content = readFileSync(signKeyFile, 'utf8')
+    assert.strictEqual(content, signKey + '\n')
+    assert.strictEqual(content.split('\n').filter(Boolean).length, 3, 'multi-line key preserved')
+    assert.strictEqual(statSync(signKeyFile).mode & 0o777, 0o600)
+  })
+
+  test('GIT_SIGN_KEY unset — no signing config, unsigned commit (no regression)', async () => {
+    rmSync(signKeyFile, {force: true})
+    const mock = createMock(gitResponses({
+      log: '+++fix: plain unsigned release____uns1__uns1full',
+    }))
+    await run(mock)
+
+    assert.ok(!has(mock.calls, 'gpg.format'))
+    assert.ok(!has(mock.calls, 'user.signingkey'))
+    assert.ok(!has(mock.calls, 'commit.gpgsign'))
+    assert.ok(!has(mock.calls, 'tag.gpgsign'))
+    // commit is still created and pushed — just unsigned
+    assert.ok(has(mock.calls, 'git commit'))
+    assert.ok(has(mock.calls, 'git push'))
+    assert.ok(!existsSync(signKeyFile), 'no key file when GIT_SIGN_KEY is unset')
+  })
+
+  test('dry run with GIT_SIGN_KEY — writes no key file and changes no git config', async () => {
+    rmSync(signKeyFile, {force: true})
+    const mock = createMock(gitResponses({
+      log: '+++fix: dry signed run____dry1__dry1full',
+    }))
+    await run(mock, {DRY_RUN: 'true', GIT_SIGN_KEY: signKey})
+
+    assert.ok(!has(mock.calls, 'gpg.format'))
+    assert.ok(!has(mock.calls, 'commit.gpgsign'))
+    assert.ok(!has(mock.calls, 'user.signingkey'))
+    // guard returns before the post-guard config/commit section runs at all
+    assert.ok(!has(mock.calls, 'git config user.name'))
+    assert.ok(!has(mock.calls, 'git push'))
+    assert.ok(!existsSync(signKeyFile), 'dry run must not write the signing key file')
   })
 })


### PR DESCRIPTION
Branch [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets) with **Require signed commits** reject the release commit, because zx-semrel creates it with a plain, unsigned local `git commit`. Set `GIT_SIGN_KEY` to sign the release commit **and** tag with SSH.

`GIT_SIGN_KEY` — the **private** SSH key of the committer identity (the full multi-line key, e.g. the contents of an `id_ed25519` file). When set, zx-semrel writes it to a temporary `0600` file and enables SSH signing via **local** git config only (`gpg.format ssh`, `user.signingkey`, `commit.gpgsign`, `tag.gpgsign`) — it never touches your global git config. When unset, behaviour is unchanged (unsigned commit).

```yaml
# .github/workflows/release.yml
env:
  GIT_COMMITTER_NAME: Semrel Extra Bot
  GIT_COMMITTER_EMAIL: bot@example.com          # must be a verified email on the account below
  GIT_SIGN_KEY: ${{ secrets.GIT_SIGN_KEY }}     # PEM-format private key, incl. the BEGIN/END lines
```
- [x] New code is covered by tests
- [x] All the changes are mentioned in docs (readme.md)
